### PR TITLE
Change the do_add_member/2 function to use PUT instead of POST and add destroy_member/2

### DIFF
--- a/test/api/list_test.exs
+++ b/test/api/list_test.exs
@@ -37,7 +37,7 @@ defmodule ExChimp.ListTest do
   test "add member to list" do
     use_cassette :stub,
       url: "https://us12.api.mailchimp.com/3.0/lists/asdf1234/members",
-      method: "post",
+      method: "put",
       status_code: ["HTTP/1.1", 200, "OK"],
       body: @list_add_member_success_json do
       {:ok, body} =


### PR DESCRIPTION
I changed the `do_add_member/2` function to use `PUT` instead of `POST` in order for us to update the subscription status from the API.

I also added a function to perm. delete a signup.